### PR TITLE
11章

### DIFF
--- a/app/assets/stylesheets/account_activeations.scss
+++ b/app/assets/stylesheets/account_activeations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AccountActiveations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/account_activeations_controller.rb
+++ b/app/controllers/account_activeations_controller.rb
@@ -1,0 +1,2 @@
+class AccountActiveationsController < ApplicationController
+end

--- a/app/controllers/account_activeations_controller.rb
+++ b/app/controllers/account_activeations_controller.rb
@@ -1,2 +1,17 @@
 class AccountActiveationsController < ApplicationController
+
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.activate
+      user.update_attribute(:activated.true)
+      user.update_attribute(:activated_at, Time.zone.now)
+      log_in user
+      flash[:success] = "Account activated!"
+      redirect_to user
+    else
+      flash[:danger] = "Invalid activation link"
+      redirect_to root_url
+    end
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,9 +6,16 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
-      log_in user
-      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
-      redirect_back_or user
+      if user.activated?
+        log_in user
+        params[:session][:remember_me] == '1' ? remember(user) : forget(user)
+        redirect_back_or user
+      else
+        message = "Account not activated."
+        message += "Check your email for the activation link."
+        flash[:warning] = message
+        redirect_to root_url
+      end
     else
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,9 +18,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      log_in @user
-      flash[:success] = "Welcome to the Sample App!"
-      redirect_to @user
+      @user.send_activation_email
+      flash[:info] = "Please check your email to activate your account."
+      redirect_to root_url
     else
       render 'new'
     end

--- a/app/helpers/account_activeations_helper.rb
+++ b/app/helpers/account_activeations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActiveationsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -18,7 +18,7 @@ module SessionsHelper
       @current_user ||= User.find_by(id: user_id)
     else if (user_id = cookies.encrypted[:user_id])
          user = User.find_by(id: user_id)
-         if user && user.authenticated?(cookies[:remember_token])
+         if user && user.authenticated?(:remember, cookies[:remember_token])
            log_in user
            @current_user = user
          end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'noreply@example.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,25 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.account_activation.subject
+  #
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.password_reset.subject
+  #
+
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: "Account activation"
+  end
+
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token
+  attr_accessor :remember_token, :activation_token
+  before_save :downcase_email
+  before_create :create_activation_digest
   before_save { self.email = email.downcase }
   validates :name, presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
@@ -36,5 +38,16 @@ class User < ApplicationRecord
   # ユーザーのログイン情報を破棄する
   def forget
     update_attribute(:remember_digest, nil)
+  end
+  
+  # メールアドレスを全て小文字にする
+  def downcase_email
+    self.email = email.downcase
+  end
+
+  # 有効化トークンとダイジェストを作成および代入する
+  def create_activation_digest
+    self.activation_token = User.new_token
+    self.activation_digest = User.digest(activation_token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,24 +30,43 @@ class User < ApplicationRecord
   end
 
   # 渡されたトークンがダイジェストと一致したらtrueを返す
-  def authenticated?(remember_token)
-    return false if remember_digest.nil?
-    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  # def authenticated?(remember_token)
+  #   return false if remember_digest.nil?
+  #   BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  # end
+
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
+    BCrypt::Password.new(digest).is_password?(token)
   end
 
   # ユーザーのログイン情報を破棄する
   def forget
     update_attribute(:remember_digest, nil)
   end
-  
-  # メールアドレスを全て小文字にする
-  def downcase_email
-    self.email = email.downcase
+
+  # アカウアントを有効にする
+  def activate
+    update_attribute(:activated, true)
+    update_attribute(:activated_at, Time.zon.now)
   end
 
-  # 有効化トークンとダイジェストを作成および代入する
-  def create_activation_digest
-    self.activation_token = User.new_token
-    self.activation_digest = User.digest(activation_token)
+  # 有効化用のメールを送信する
+  def send_activation_email
+    UserMailer.account_activation(self).deliver_now
   end
+
+  private
+  
+    # メールアドレスを全て小文字にする
+    def downcase_email
+      self.email = email.downcase
+    end
+
+    # 有効化トークンとダイジェストを作成および代入する
+    def create_activation_digest
+      self.activation_token = User.new_token
+      self.activation_digest = User.digest(activation_token)
+    end
 end

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -1,0 +1,10 @@
+<h1>Sample App</h1>
+
+<p>Hi <%= @user.name %>,</p>
+
+<p>
+  Welcome to the Sample App! Click on the link below to activate your account:
+</p>
+
+<%= link_to "Activate", edit_account_activation_url(@user.activation_token,
+                                                    email: @user.email) %>

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -1,0 +1,3 @@
+Hi <%= @user.name %>,
+Welcome to the Sample App! Click on the link below to activate your account:
+<%= edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1>User#password_reset</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+User#password_reset
+
+<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,10 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  host = "localhost:3000"
+
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
+
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'example.com' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,6 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
 
   resources :users
+  resources :account_activations, only: [:edit]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20221004105255_add_activation_to_users.rb
+++ b/db/migrate/20221004105255_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_03_175424) do
+ActiveRecord::Schema.define(version: 2022_10_04_105255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,9 @@ ActiveRecord::Schema.define(version: 2022_10_03_175424) do
     t.string "password_digest"
     t.string "remember_digest"
     t.boolean "admin", default: false
+    t.string "activation_digest"
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,9 @@ User.create!(name:  "Example User",
              email: "example@railstutorial.org",
              password:              "foobar",
              password_confirmation: "foobar",
-             admin: true)
+             admin: true,
+             activated: true,
+             activated_at: Time.zone.now)
 
 # 追加のユーザーをまとめて生成する
 99.times do |n|
@@ -21,7 +23,9 @@ User.create!(name:  "Example User",
   User.create!(name:  name,
                email: email,
                password:              password,
-               password_confirmation: password)
+               password_confirmation: password,
+               activated: true,
+               activated_at: Time.zone.now)
 end
 
 

--- a/test/controllers/account_activeations_controller_test.rb
+++ b/test/controllers/account_activeations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AccountActiveationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -45,7 +45,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
   end
 
-  test "shoukd redirect destroy when not logged in" do
+  test "should redirect destroy when not logged in" do
     assert_no_difference 'User.count' do
       delete user_path(@user)
     end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,25 +3,35 @@ michael:
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
   admin: true
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 archer:
   name: Sterling Archer
   email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 lana:
   name: Lana Kane
   email: hands@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 malory:
   name: Malory Archer
   email: boss@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 
 <% 30.times do |n| %>
 user_<%= n %>:
   name: <%= "User #{n}" %>
   email: <%= "User-#{n}@example.com" %>
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now %>
 <% end %>

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -3,12 +3,12 @@ require "test_helper"
 class UsersIndexTest < ActionDispatch::IntegrationTest
 
   def setup
-    @user = users(:michael)
+    @admin = users(:michael)
     @non_admin = users(:archer)
   end
 
   test "index as admin including pagination and delete links" do
-    log_in_as(@user)
+    log_in_as(@admin)
     get users_path
     assert_template 'users/index'
     assert_select 'div.pagination'

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -2,6 +2,10 @@ require "test_helper"
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
 
+  def setup
+    ActionMailer::Base.deliveries.clear
+  end
+
   test "invalid signup information" do
     get signup_path
     assert_no_difference 'User.count' do
@@ -11,8 +15,11 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                                          password_confirmation: "bar" } }
     end
     assert_template 'users/new'
+    assert_select 'div#error_explanation'
+    assert_select 'div.field_with_errors'
   end
-  test "valid signup information" do
+
+  test "valid signup information with account activation" do
     get signup_path
     assert_difference 'User.count', 1 do
       post users_path, params: { user: { name: "Example User",
@@ -20,6 +27,21 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                                          password: "password",
                                          password_confirmation: "password" } }
     end
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    user = assigns(:user)
+    assert_not user.activated?
+    # 有効化していない状態でログインしてみる
+    log_in_as(user)
+    assert_not is_logged_in?
+    # 有効化トークンが不正な場合
+    get edit_account_activation_path("invalid token", email: user.email)
+    assert_not is_logged_in?
+    # トークンは正しいがメールアドレスが無効な場合
+    get edit_account_activation_path(user.activation_token, email: "wrong")
+    assert_not is_logged_in?
+    #有効化トークンが正しい場合
+    get edit_account_activation_path(user.activation_token, email: user.email)
+    assert user.reload.activated?
     follow_redirect!
     assert_template 'users/show'
     assert is_logged_in?

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,16 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class UserMailerTest < ActionMailer::TestCase
+  test "account_activation" do
+    user = users(:michael)
+    user.activation_token = User.new_token
+    mail = UserMailer.account_activation(user)
+    assert_equal "Account activation", mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.name,mail.body.encoded
+    assert_match user.activation_token,mail.body.encoded
+    assert_match CGI.escape(user.email), mail.body.encoded
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -67,6 +67,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "authenticated? should return false for a user with nil digest" do
-    assert_not @user.authenticated?('')
+    assert_not @user.authenticated?(:remember, '')
   end
 end


### PR DESCRIPTION
## やったこと
rails チュートリアル11章
https://railstutorial.jp/chapters/account_activation?version=6.0#cha-account_activation

## 気持ち
とうとうエラー解決できなかった。。。

11.3.3 有効化のテストとリファクタリングで発生
ログは以下
```
root@70eb09ddbc4c:/app# rails t
Running via Spring preloader in process 705
Running via Spring preloader in process 710
rake aborted!
TypeError: no implicit conversion of nil into String
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/connection_adapters/postgresql/utils.rb:26:in `quote_ident'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/connection_adapters/postgresql/utils.rb:26:in `quoted'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/connection_adapters/postgresql/quoting.rb:33:in `quote_table_name'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/connection_adapters/postgresql/schema_statements.rb:54:in `drop_database'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/tasks/postgresql_database_tasks.rb:32:in `drop'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/tasks/postgresql_database_tasks.rb:45:in `purge'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/tasks/database_tasks.rb:293:in `purge'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/railties/databases.rake:615:in `block (4 levels) in <main>'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/railties/databases.rake:614:in `each'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/railties/databases.rake:614:in `block (3 levels) in <main>'
/usr/local/bundle/gems/activerecord-6.1.7/lib/active_record/railties/databases.rake:622:in `block (3 levels) in <main>'
/usr/local/bundle/gems/activesupport-6.1.7/lib/active_support/fork_tracker.rb:10:in `block in fork'
/usr/local/bundle/gems/activesupport-6.1.7/lib/active_support/fork_tracker.rb:10:in `block in fork'
/usr/local/bundle/gems/activesupport-6.1.7/lib/active_support/fork_tracker.rb:8:in `fork'
/usr/local/bundle/gems/activesupport-6.1.7/lib/active_support/fork_tracker.rb:8:in `fork'
/usr/local/bundle/gems/activesupport-6.1.7/lib/active_support/fork_tracker.rb:27:in `fork'
/usr/local/bundle/gems/activesupport-6.1.7/lib/active_support/fork_tracker.rb:8:in `fork'
/usr/local/bundle/gems/activesupport-6.1.7/lib/active_support/fork_tracker.rb:27:in `fork'
<internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:/usr/local/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'
Tasks: TOP => db:test:load => db:test:purge
(See full trace by running task with --trace)
Run options: --seed 27763

# Running:

.....E

Error:
UsersSignupTest#test_valid_signup_information_with_account_activation:
ActionController::RoutingError: uninitialized constant AccountActivationsController

        Object.const_get(camel_cased_word)
              ^^^^^^^^^^
Did you mean?  AccountActiveationsController
               AccountActiveationsControllerTest

            old_raise.call(*args)
                     ^^^^^
    test/integration/users_signup_test.rb:37:in `block in <class:UsersSignupTest>'


rails test test/integration/users_signup_test.rb:22

.................................

Finished in 3.382738s, 11.5291 runs/s, 49.0727 assertions/s.
39 runs, 166 assertions, 0 failures, 1 errors, 0 skips